### PR TITLE
feat: Use custom error pages

### DIFF
--- a/disabled/portainer.yml
+++ b/disabled/portainer.yml
@@ -30,6 +30,9 @@ services:
         - traefik.port=9000
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:portainer.chaosdorf.space,portainer
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
   agent:
     image: portainer/agent:latest
     environment:

--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -34,6 +34,9 @@ services:
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:pizza.chaosdorf.space
         - traefik.frontend.entryPoints=https
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
   db:
     image: postgres:9.6
     environment:

--- a/enabled/error.yml
+++ b/enabled/error.yml
@@ -1,0 +1,30 @@
+version: '3.7'
+
+services:
+  app:
+    image: guillaumebriday/traefik-custom-error-pages:latest
+    networks:
+      - traefik
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 100M
+        reservations:
+          cpus: '0.125'
+          memory: 5M
+      labels:
+        - traefik.docker.network=traefik_net
+        - traefik.port=80
+        - traefik.frontend.rule=HostRegexp:{catchall:.*}
+        - traefik.frontend.priority=9 # low priority as fallback
+
+networks:
+  traefik:
+    driver: overlay
+    external: true
+    name: traefik_net

--- a/enabled/fftalks.yml
+++ b/enabled/fftalks.yml
@@ -22,6 +22,9 @@ services:
         - traefik.port=5000
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:fftalks.chaosdorf.space,fftalks
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,429,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 networks:
   traefik:

--- a/enabled/labello.yml
+++ b/enabled/labello.yml
@@ -26,6 +26,9 @@ services:
         - traefik.port=8000
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:labello.chaosdorf.space,labello
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 networks:
   traefik:

--- a/enabled/prittstift.yml
+++ b/enabled/prittstift.yml
@@ -42,6 +42,9 @@ services:
         - traefik.port=8000
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:prittstift.chaosdorf.space,prittstift
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 networks:
   traefik:

--- a/enabled/pulseweb.yml
+++ b/enabled/pulseweb.yml
@@ -25,6 +25,9 @@ services:
         - traefik.port=8000
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:pulseweb.chaosdorf.space,pulseweb
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 networks:
   traefik:

--- a/enabled/traefik.yml
+++ b/enabled/traefik.yml
@@ -42,6 +42,9 @@ services:
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:traefik.chaosdorf.space,traefik
         - traefik.frontend.entryPoints=https
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 volumes:
   acme:

--- a/enabled/ympd.yml
+++ b/enabled/ympd.yml
@@ -25,6 +25,9 @@ services:
         - traefik.port=8080
         - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:ympd.chaosdorf.space,ympd
+        - traefik.frontend.errors.network.backend=error-app
+        - traefik.frontend.errors.network.status=401,403,404,429,500,503
+        - traefik.frontend.errors.network.query=/{status}.html
 
 networks:
   traefik:


### PR DESCRIPTION
This uses https://github.com/guillaumebriday/traefik-custom-error-pages for pretty error pages.

I took care of checking whether each app has a nice page for each error code and if not (and we have a generic nice one) that is displayed instead.