### PR TITLE
feat: Enable HSTS (closes #9)

### DIFF
--- a/disabled/portainer.yml
+++ b/disabled/portainer.yml
@@ -28,6 +28,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=9000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:portainer.chaosdorf.space,portainer
   agent:
     image: portainer/agent:latest

--- a/disabled/swarmpit.yml
+++ b/disabled/swarmpit.yml
@@ -29,6 +29,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8080
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:swarmpit.chaosdorf.space,swarmpit
   agent:
     image: swarmpit/agent:2.0

--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -31,6 +31,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:pizza.chaosdorf.space
         - traefik.frontend.entryPoints=https
   db:

--- a/enabled/dashpi.yml
+++ b/enabled/dashpi.yml
@@ -26,8 +26,8 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=3030
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:dashboard.chaosdorf.space,dashboard
-
 networks:
   traefik:
     driver: overlay

--- a/enabled/fftalks.yml
+++ b/enabled/fftalks.yml
@@ -20,6 +20,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=5000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:fftalks.chaosdorf.space,fftalks
 
 networks:

--- a/enabled/labello.yml
+++ b/enabled/labello.yml
@@ -24,6 +24,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:labello.chaosdorf.space,labello
 
 networks:

--- a/enabled/mete.yml
+++ b/enabled/mete.yml
@@ -23,6 +23,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=80
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:mete.chaosdorf.space,mete
   db:
     image: postgres:10-alpine

--- a/enabled/prittstift.yml
+++ b/enabled/prittstift.yml
@@ -40,6 +40,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:prittstift.chaosdorf.space,prittstift
 
 networks:

--- a/enabled/pulseweb.yml
+++ b/enabled/pulseweb.yml
@@ -23,6 +23,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8000
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:pulseweb.chaosdorf.space,pulseweb
 
 networks:

--- a/enabled/traefik.yml
+++ b/enabled/traefik.yml
@@ -39,6 +39,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8080
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:traefik.chaosdorf.space,traefik
         - traefik.frontend.entryPoints=https
 

--- a/enabled/ympd.yml
+++ b/enabled/ympd.yml
@@ -23,6 +23,7 @@ services:
       labels:
         - traefik.docker.network=traefik_net
         - traefik.port=8080
+        - traefik.frontend.headers.STSSeconds=2592000
         - traefik.frontend.rule=Host:ympd.chaosdorf.space,ympd
 
 networks:


### PR DESCRIPTION
People are still not being redirected from HTTP to HTTPS
automatically, but if they opt-in their browser is going
to remember their choice.

This is in line with our old setup before Traefik.