### PR TITLE
Add Sentry

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,5 +35,7 @@ Vagrant.configure("2") do |config|
     echo "foo" | docker secret create CF_API_KEY -
     echo "admin:traefik:817374111f31cc282162486425ee5e9e" | docker secret create TRAEFIK_DIGEST_AUTH - # admin:admin
     cd /vagrant && ./deploy-stacks.sh
+    docker exec $(docker ps -q -f name=sentry_snuba-api) ./docker_entrypoint.sh bootstrap --force
+    docker exec $(docker ps -q -f name=sentry_web) ./docker-entrypoint.sh upgrade --noinput
   SHELL
 end

--- a/configs/sentry-config.yml
+++ b/configs/sentry-config.yml
@@ -1,0 +1,87 @@
+# While a lot of configuration in Sentry can be changed via the UI, for all
+# new-style config (as of 8.0) you can also declare values here in this file
+# to enforce defaults or to ensure they cannot be changed via the UI. For more
+# information see the Sentry documentation.
+
+###############
+# Mail Server #
+###############
+
+mail.backend: 'smtp'  # Use dummy if you want to disable email entirely
+mail.host: 'intern.chaosdorf.de'
+mail.port: 587
+mail.username: 'raumrelay'
+mail.password: '<<< nope >>>'
+mail.use-tls: true
+# The email address to send on behalf of
+mail.from: 'raumrelay@chaosdorf.de'
+
+# If you'd like to configure email replies, enable this.
+# mail.enable-replies: false
+
+# When email-replies are enabled, this value is used in the Reply-To header
+# mail.reply-hostname: ''
+
+# If you're using mailgun for inbound mail, set your API key and configure a
+# route to forward to /api/hooks/mailgun/inbound/
+# mail.mailgun-api-key: ''
+
+###################
+# System Settings #
+###################
+
+# If this file ever becomes compromised, it's important to regenerate your a new key
+# Changing this value will result in all current sessions being invalidated.
+# A new key can be generated with `$ sentry config generate-secret-key`
+system.secret-key: '<<< nope >>>'
+
+# The ``redis.clusters`` setting is used, unsurprisingly, to configure Redis
+# clusters. These clusters can be then referred to by name when configuring
+# backends such as the cache, digests, or TSDB backend.
+#
+# Two types of clusters are currently supported:
+#
+#   rb.Cluster
+#   A redis blaster cluster is the traditional cluster used by most services
+#   within sentry. This is the default type cluster type.
+#
+#   rediscluster.StrictRedisCluster
+#   An official Redis Cluster can be configured by marking the named group with
+#   the ``is_redis_cluster: True`` flag. In future versions of Sentry more
+#   services will require this type of cluster.
+#
+redis.clusters:
+  default:
+    hosts:
+      0:
+        host: redis
+        port: 6379
+
+################
+# File storage #
+################
+
+# Uploaded media uses these `filestore` settings. The available
+# backends are: `filesystem`, `gcs`, and `s3`.
+
+filestore.backend: 'filesystem'
+filestore.options:
+  location: '/var/lib/sentry/files'
+
+# NOTE: See docs/filestore for instructions on configuring the shell environment
+#       with authentication credentials for Google Cloud.
+# filestore.backend: 'gcs'
+# filestore.options:
+#   bucket_name: 's3-bucket-name'
+
+# filestore.backend: 's3'
+# filestore.options:
+#   access_key: 'AKIXXXXXX'
+#   secret_key: 'XXXXXXX'
+#   bucket_name: 's3-bucket-name'
+
+github-app.id: 36159
+github-app.name: 'chaosdorf-sentry'
+github-app.private-key: 'privatekey'
+github-app.client-id: ''
+github-app.client-secret: ''

--- a/configs/sentry.conf.py
+++ b/configs/sentry.conf.py
@@ -1,0 +1,132 @@
+# This file is just Python, with a touch of Django which means
+# you can inherit and tweak settings to your hearts content.
+from sentry.conf.server import *
+
+import os.path
+
+CONF_ROOT = os.path.dirname(__file__)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'sentry.db.postgres',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'HOST': 'postgres',
+        'PORT': '',
+    }
+}
+
+# You should not change this setting after your database has been created
+# unless you have altered all schemas first
+SENTRY_USE_BIG_INTS = True
+
+# If you're expecting any kind of real traffic on Sentry, we highly recommend
+# configuring the CACHES and Redis settings
+
+###########
+# General #
+###########
+
+# Instruct Sentry that this install intends to be run by a single organization
+# and thus various UI optimizations should be enabled.
+SENTRY_SINGLE_ORGANIZATION = True
+DEBUG = False
+
+#########
+# Cache #
+#########
+
+# Sentry currently utilizes two separate mechanisms. While CACHES is not a
+# requirement, it will optimize several high throughput patterns.
+
+# If you wish to use memcached, install the dependencies and adjust the config
+# as shown:
+#
+#   pip install python-memcached
+#
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#         'LOCATION': ['127.0.0.1:11211'],
+#     }
+# }
+
+# A primary cache is required for things such as processing events
+SENTRY_CACHE = 'sentry.cache.redis.RedisCache'
+
+#########
+# Queue #
+#########
+
+# See https://docs.sentry.io/on-premise/server/queue/ for more
+# information on configuring your queue broker and workers. Sentry relies
+# on a Python framework called Celery to manage queues.
+
+BROKER_URL = 'redis://redis:6379'
+
+###############
+# Rate Limits #
+###############
+
+# Rate limits apply to notification handlers and are enforced per-project
+# automatically.
+
+SENTRY_RATELIMITER = 'sentry.ratelimits.redis.RedisRateLimiter'
+
+##################
+# Update Buffers #
+##################
+
+# Buffers (combined with queueing) act as an intermediate layer between the
+# database and the storage API. They will greatly improve efficiency on large
+# numbers of the same events being sent to the API in a short amount of time.
+# (read: if you send any kind of real data to Sentry, you should enable buffers)
+
+SENTRY_BUFFER = 'sentry.buffer.redis.RedisBuffer'
+
+##########
+# Quotas #
+##########
+
+# Quotas allow you to rate limit individual projects or the Sentry install as
+# a whole.
+
+SENTRY_QUOTAS = 'sentry.quotas.redis.RedisQuota'
+
+########
+# TSDB #
+########
+
+# The TSDB is used for building charts as well as making things like per-rate
+# alerts possible.
+
+SENTRY_TSDB = 'sentry.tsdb.redissnuba.RedisSnubaTSDB'
+
+###########
+# Digests #
+###########
+
+# The digest backend powers notification summaries.
+
+SENTRY_DIGESTS = 'sentry.digests.backends.redis.RedisBackend'
+
+##############
+# Web Server #
+##############
+
+# If you're using a reverse SSL proxy, you should enable the X-Forwarded-Proto
+# header and uncomment the following settings
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+SENTRY_WEB_HOST = '127.0.0.1'
+SENTRY_WEB_PORT = 8000
+SENTRY_WEB_OPTIONS = {
+    # 'workers': 3,  # the number of web workers
+    # 'protocol': 'uwsgi',  # Enable uwsgi protocol instead of http
+}
+
+# disable registrations
+SENTRY_FEATURES['auth:register'] = False

--- a/enabled/sentry.yml
+++ b/enabled/sentry.yml
@@ -63,6 +63,19 @@ services:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
     volumes:
       - 'sentry-postgres:/var/lib/postgresql/data'
+  postgres-backup:
+    << : *defaults
+    image: nomaster/postgres-backup
+    volumes:
+      - sentry-postgres-backup:/backup
+    environment:
+      PGHOST: postgres
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5
   zookeeper:
     << : *defaults
     image: 'confluentinc/cp-zookeeper:5.5.0'
@@ -104,6 +117,19 @@ services:
     volumes:
       - 'sentry-clickhouse:/var/lib/clickhouse'
       - 'sentry-clickhouse-log:/var/log/clickhouse-server'
+  clickhouse-backup:
+    << : *defaults
+    image: ytvwld/clickhouse-backup
+    environment:
+        TABLE: sentry_local
+    volumes:
+      - sentry-clickhouse-backup:/backup
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5
   snuba-api:
     << : *snuba_defaults
   # Kafka consumer responsible for feeding events into Clickhouse
@@ -227,6 +253,8 @@ volumes:
   sentry-zookeeper-log:
   sentry-kafka-log:
   sentry-clickhouse-log:
+  sentry-postgres-backup:
+  sentry-clickhouse-backup:
 configs:
   yaml:
     file: ../configs/sentry-config.yml

--- a/enabled/sentry.yml
+++ b/enabled/sentry.yml
@@ -32,7 +32,7 @@ x-sentry-defaults: &sentry_defaults
     - source: python
       target: /etc/sentry/sentry.conf.py
   volumes:
-    - 'sentry-data:/data'
+    - 'data:/data'
 x-snuba-defaults: &snuba_defaults
   << : *defaults
   depends_on:
@@ -55,19 +55,19 @@ services:
     << : *defaults
     image: 'redis:5.0-alpine'
     volumes:
-      - 'sentry-redis:/data'
+      - 'redis:/data'
   postgres:
     << : *defaults
     image: 'postgres:9.6'
     environment:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
     volumes:
-      - 'sentry-postgres:/var/lib/postgresql/data'
+      - 'postgres:/var/lib/postgresql/data'
   postgres-backup:
     << : *defaults
     image: nomaster/postgres-backup
     volumes:
-      - sentry-postgres-backup:/backup
+      - postgres-backup:/backup
     environment:
       PGHOST: postgres
     deploy:
@@ -85,9 +85,9 @@ services:
       ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: 'WARN'
       ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: 'WARN'
     volumes:
-      - 'sentry-zookeeper:/var/lib/zookeeper/data'
-      - 'sentry-zookeeper-log:/var/lib/zookeeper/log'
-      - 'sentry-secrets:/etc/zookeeper/secrets'
+      - 'zookeeper:/var/lib/zookeeper/data'
+      - 'zookeeper-log:/var/lib/zookeeper/log'
+      - 'secrets:/etc/zookeeper/secrets'
   kafka:
     << : *defaults
     depends_on:
@@ -104,9 +104,9 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
     volumes:
-      - 'sentry-kafka:/var/lib/kafka/data'
-      - 'sentry-kafka-log:/var/lib/kafka/log'
-      - 'sentry-secrets:/etc/kafka/secrets'
+      - 'kafka:/var/lib/kafka/data'
+      - 'kafka-log:/var/lib/kafka/log'
+      - 'secrets:/etc/kafka/secrets'
   clickhouse:
     << : *defaults
     image: 'yandex/clickhouse-server:19.17'
@@ -115,15 +115,15 @@ services:
     #     soft: 262144
     #     hard: 262144
     volumes:
-      - 'sentry-clickhouse:/var/lib/clickhouse'
-      - 'sentry-clickhouse-log:/var/log/clickhouse-server'
+      - 'clickhouse:/var/lib/clickhouse'
+      - 'clickhouse-log:/var/log/clickhouse-server'
   clickhouse-backup:
     << : *defaults
     image: ytvwld/clickhouse-backup
     environment:
         TABLE: sentry_local
     volumes:
-      - sentry-clickhouse-backup:/backup
+      - clickhouse-backup:/backup
     deploy:
       mode: replicated
       replicas: 1
@@ -161,7 +161,7 @@ services:
   #   << : *defaults
   #   image: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
   #   volumes:
-  #     - 'sentry-symbolicator:/data'
+  #     - 'symbolicator:/data'
   #   command: run
   # symbolicator-cleanup:
   #   << : *defaults
@@ -172,7 +172,7 @@ services:
   #       BASE_IMAGE: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
   #   command: '"55 23 * * * gosu symbolicator symbolicator cleanup"'
   #   volumes:
-  #     - 'sentry-symbolicator:/data'
+  #     - 'symbolicator:/data'
   web:
     << : *sentry_defaults
     networks:
@@ -235,26 +235,19 @@ services:
   #     - kafka
   #     - redis
 volumes:
-  sentry-data:
-    external: true
-  sentry-postgres:
-    external: true
-  sentry-redis:
-    external: true
-  sentry-zookeeper:
-    external: true
-  sentry-kafka:
-    external: true
-  sentry-clickhouse:
-    external: true
-  # sentry-symbolicator:
-  #   external: true
-  sentry-secrets:
-  sentry-zookeeper-log:
-  sentry-kafka-log:
-  sentry-clickhouse-log:
-  sentry-postgres-backup:
-  sentry-clickhouse-backup:
+  data:
+  postgres:
+  redis:
+  zookeeper:
+  kafka:
+  clickhouse:
+  # symbolicator:
+  secrets:
+  zookeeper-log:
+  kafka-log:
+  clickhouse-log:
+  postgres-backup:
+  clickhouse-backup:
 configs:
   yaml:
     file: ../configs/sentry-config.yml

--- a/enabled/sentry.yml
+++ b/enabled/sentry.yml
@@ -1,0 +1,242 @@
+# based on https://github.com/getsentry/onpremise for 20.6
+version: '3.7'
+x-defaults: &defaults
+  networks:
+    - internal
+  deploy:
+    mode: replicated
+    replicas: 1
+    restart_policy:
+      delay: 60s
+      max_attempts: 5
+x-sentry-defaults: &sentry_defaults
+  << : *defaults
+  image: getsentry/sentry:20.6.0
+  depends_on:
+    - redis
+    - postgres
+    - memcached
+    - snuba-api
+    - snuba-consumer
+    - snuba-outcomes-consumer
+    - snuba-sessions-consumer
+    - snuba-replacer
+    # - symbolicator
+    - kafka
+  environment:
+    SENTRY_CONF: '/etc/sentry'
+    SNUBA: 'http://snuba-api:1218'
+  configs:
+    - source: yaml
+      target: /etc/sentry/config.yml
+    - source: python
+      target: /etc/sentry/sentry.conf.py
+  volumes:
+    - 'sentry-data:/data'
+x-snuba-defaults: &snuba_defaults
+  << : *defaults
+  depends_on:
+    - redis
+    - clickhouse
+    - kafka
+  image: getsentry/snuba:20.6.0
+  environment:
+    SNUBA_SETTINGS: docker
+    CLICKHOUSE_HOST: clickhouse
+    DEFAULT_BROKERS: 'kafka:9092'
+    REDIS_HOST: redis
+    UWSGI_MAX_REQUESTS: '10000'
+    UWSGI_DISABLE_LOGGING: 'true'
+services:
+  memcached:
+    << : *defaults
+    image: 'memcached:1.5-alpine'
+  redis:
+    << : *defaults
+    image: 'redis:5.0-alpine'
+    volumes:
+      - 'sentry-redis:/data'
+  postgres:
+    << : *defaults
+    image: 'postgres:9.6'
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
+    volumes:
+      - 'sentry-postgres:/var/lib/postgresql/data'
+  zookeeper:
+    << : *defaults
+    image: 'confluentinc/cp-zookeeper:5.5.0'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
+      ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: 'WARN'
+      ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: 'WARN'
+    volumes:
+      - 'sentry-zookeeper:/var/lib/zookeeper/data'
+      - 'sentry-zookeeper-log:/var/lib/zookeeper/log'
+      - 'sentry-secrets:/etc/zookeeper/secrets'
+  kafka:
+    << : *defaults
+    depends_on:
+      - zookeeper
+    image: 'confluentinc/cp-kafka:5.5.0'
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
+      KAFKA_MESSAGE_MAX_BYTES: '50000000' #50MB or bust
+      KAFKA_MAX_REQUEST_SIZE: '50000000' #50MB on requests apparently too
+      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
+      KAFKA_LOG4J_LOGGERS: 'kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN'
+      KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
+      KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
+    volumes:
+      - 'sentry-kafka:/var/lib/kafka/data'
+      - 'sentry-kafka-log:/var/lib/kafka/log'
+      - 'sentry-secrets:/etc/kafka/secrets'
+  clickhouse:
+    << : *defaults
+    image: 'yandex/clickhouse-server:19.17'
+    # ulimits:
+    #   nofile:
+    #     soft: 262144
+    #     hard: 262144
+    volumes:
+      - 'sentry-clickhouse:/var/lib/clickhouse'
+      - 'sentry-clickhouse-log:/var/log/clickhouse-server'
+  snuba-api:
+    << : *snuba_defaults
+  # Kafka consumer responsible for feeding events into Clickhouse
+  snuba-consumer:
+    << : *snuba_defaults
+    command: consumer --storage events --auto-offset-reset=latest --max-batch-time-ms 750
+  # Kafka consumer responsible for feeding outcomes into Clickhouse
+  # Use --auto-offset-reset=earliest to recover up to 7 days of TSDB data
+  # since we did not do a proper migration
+  snuba-outcomes-consumer:
+    << : *snuba_defaults
+    command: consumer --storage outcomes_raw --auto-offset-reset=earliest --max-batch-time-ms 750
+  # Kafka consumer responsible for feeding session data into Clickhouse
+  snuba-sessions-consumer:
+    << : *snuba_defaults
+    command: consumer --storage sessions_raw --auto-offset-reset=latest --max-batch-time-ms 750
+  snuba-replacer:
+    << : *snuba_defaults
+    command: replacer --storage events --auto-offset-reset=latest --max-batch-size 3
+  # snuba-cleanup:
+  #   << : *snuba_defaults
+  #   image: snuba-cleanup-onpremise-local
+  #   build:
+  #     context: ./cron
+  #     args:
+  #       BASE_IMAGE: 'getsentry/snuba:$SENTRY_VERSION'
+  #   command: '"*/5 * * * * gosu snuba snuba cleanup --dry-run False"'
+  # symbolicator:
+  #   << : *defaults
+  #   image: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
+  #   volumes:
+  #     - 'sentry-symbolicator:/data'
+  #   command: run
+  # symbolicator-cleanup:
+  #   << : *defaults
+  #   image: symbolicator-cleanup-onpremise-local
+  #   build:
+  #     context: ./cron
+  #     args:
+  #       BASE_IMAGE: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
+  #   command: '"55 23 * * * gosu symbolicator symbolicator cleanup"'
+  #   volumes:
+  #     - 'sentry-symbolicator:/data'
+  web:
+    << : *sentry_defaults
+    networks:
+      - internal
+      - traefik
+    command: run web --bind 0.0.0.0
+    deploy:
+      labels:
+        - traefik.docker.network=traefik_net
+        - traefik.http.services.sentry.loadbalancer.server.port=8000
+        - "traefik.http.routers.sentry-https.rule=Host(`sentry.chaosdorf.space`)"
+        - traefik.http.routers.sentry-https.middlewares=global-headers@file
+        - traefik.http.routers.sentry-https.service=sentry@docker
+        - traefik.http.routers.sentry-https.tls=true
+        - traefik.http.routers.sentry-https.tls.certresolver=default
+        - traefik.http.routers.sentry-https.tls.domains[0].main=*.chaosdorf.space
+  cron:
+    << : *sentry_defaults
+    command: run cron
+  worker:
+    << : *sentry_defaults
+    command: run worker
+  ingest-consumer:
+    << : *sentry_defaults
+    command: run ingest-consumer --all-consumer-types
+  post-process-forwarder:
+    << : *sentry_defaults
+    # Increase `--commit-batch-size 1` below to deal with high-load environments.
+    command: run post-process-forwarder --commit-batch-size 1
+  # sentry-cleanup:
+  #   << : *sentry_defaults
+  #   image: sentry-cleanup-onpremise-local
+  #   build:
+  #     context: ./cron
+  #     args:
+  #       BASE_IMAGE: 'sentry-onpremise-local'
+  #   command: '"0 0 * * * gosu sentry sentry cleanup --days $SENTRY_EVENT_RETENTION_DAYS"'
+  # nginx:
+  #   << : *defaults
+  #   ports:
+  #     - '9000:80/tcp'
+  #   image: 'nginx:1.16'
+  #   volumes:
+  #     - type: bind
+  #       read_only: true
+  #       source: ./nginx
+  #       target: /etc/nginx
+  #   depends_on:
+  #     - web
+  #     - relay
+  # relay:
+  #   << : *defaults
+  #   image: 'getsentry/relay:20.6.0'
+  #   volumes:
+  #     - type: bind
+  #       read_only: true
+  #       source: ./relay
+  #       target: /work/.relay
+  #   depends_on:
+  #     - kafka
+  #     - redis
+volumes:
+  sentry-data:
+    external: true
+  sentry-postgres:
+    external: true
+  sentry-redis:
+    external: true
+  sentry-zookeeper:
+    external: true
+  sentry-kafka:
+    external: true
+  sentry-clickhouse:
+    external: true
+  # sentry-symbolicator:
+  #   external: true
+  sentry-secrets:
+  sentry-zookeeper-log:
+  sentry-kafka-log:
+  sentry-clickhouse-log:
+configs:
+  yaml:
+    file: ../configs/sentry-config.yml
+  python:
+    file: ../configs/sentry.conf.py
+
+networks:
+  internal:
+    driver: overlay
+  traefik:
+    driver: overlay
+    external: true
+    name: traefik_net


### PR DESCRIPTION
This PR adds Sentry as an application. I chose Sentry 20.06 because it's the one we're currently using on its own VM.

I have tested this in so far that the application can be configured, it boots and I'm able to log in to the Web UI and click around.
I couldn't test importing our previous data because I just don't have the hardware for it.


And this might be the biggest problem: Sentry seems to explode with each release (this PR adds 18 containers) and consumes quite a bit of resources even though it should do next to nothing. I'm not even sure it will run on our hardware.

Perhaps we're better off using [GlitchTip](https://glitchtip.com/)? Sadly, I didn't see an option to import data from Sentry.