### PR TITLE
feat: Opt out of FLoC

### DIFF
--- a/configs/traefik-dynamic.toml
+++ b/configs/traefik-dynamic.toml
@@ -1,3 +1,5 @@
 [http.middlewares]
   [http.middlewares.global-headers.headers]
      STSSeconds=2592000
+     [http.middlewares.global-headers.headers.customResponseHeaders]
+      Permissions-Policy="interest-cohort=()"


### PR DESCRIPTION
FLoC ("Federated Learning of Cohorts") is a new feature of Google Chrome and a replacement for third-party tracking cookies (more details [here](https://amifloced.org/)).
Sites can opt-out of this. Even though private networks should be automatically excluded, I'm not sure whether this applies to us (and opting out doesn't hurt).