### PR TITLE
chore: Upgrade chaospizza's postgres from 9.6 to 13

### DIFF
--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -2,7 +2,14 @@ version: '3.7'
 
 services:
   db:
-    image: hello-world
+    image: tianon/postgres-upgrade:9.6-to-13
+    environment:
+      PGUSER: chaospizza
+      PGPASSWORD: chaospizza
+      POSTGRES_INITDB_ARGS: --username=chaospizza --pwfile=<(echo chaospizza)
+    volumes:
+      - database:/var/lib/postgresql/9.6/data
+      - database2:/var/lib/postgresql/13/data
     deploy:
       mode: replicated
       replicas: 1
@@ -11,6 +18,7 @@ services:
 
 volumes:
   database:
+  database2:
   backup:
 
 networks:

--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -2,14 +2,10 @@ version: '3.7'
 
 services:
   db:
-    image: tianon/postgres-upgrade:9.6-to-13
-    environment:
-      PGUSER: chaospizza
-      PGPASSWORD: chaospizza
-      POSTGRES_INITDB_ARGS: --username=chaospizza --pwfile=<(echo chaospizza)
+    image: busybox:1.34
+    command: ["sh", "-c", "echo 'host all all all md5' >> /database/pg_hba.conf"]
     volumes:
-      - database:/var/lib/postgresql/9.6/data
-      - database2:/var/lib/postgresql/13/data
+      - database2:/database
     deploy:
       mode: replicated
       replicas: 1

--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -1,19 +1,85 @@
 version: '3.7'
 
 services:
-  db:
-    image: busybox:1.34
-    command: ["sh", "-c", "echo 'host all all all md5' >> /database/pg_hba.conf"]
-    volumes:
-      - database2:/database
+  app:
+    image: chaosdorf/chaospizza:latest
+    environment:
+      - DJANGO_ALLOWED_HOSTS=pizza.chaosdorf.space
+      - DJANGO_SETTINGS_MODULE=config.settings.prod
+      - DJANGO_DATABASE_URL=postgresql://chaospizza:chaospizza@db:5432/chaospizza
+    secrets:
+      - source: CHAOSPIZZA_DJANGO_SECRET_KEY
+        target: DJANGO_SECRET_KEY
+      - source: CHAOSPIZZA_SENTRY_DSN
+        target: SENTRY_DSN
+    networks:
+      - internal
+      - traefik
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        condition: none
+        delay: 60s
+        max_attempts: 5
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 256M
+        reservations:
+          cpus: '0.125'
+          memory: 64M
+      labels:
+        - traefik.docker.network=traefik_net
+        - traefik.http.services.chaospizza.loadbalancer.server.port=8000
+        - "traefik.http.routers.chaospizza.rule=Host(`pizza.chaosdorf.space`)"
+        - traefik.http.routers.chaospizza.middlewares=global-headers@file,chaospizza-error@docker
+        - traefik.http.routers.chaospizza.service=chaospizza@docker
+        - traefik.http.routers.chaospizza.tls=true
+        - traefik.http.routers.chaospizza.tls.certresolver=default
+        - traefik.http.routers.chaospizza.tls.domains[0].main=*.chaosdorf.space
+        - traefik.http.middlewares.chaospizza-error.errors.service=error@docker
+        - traefik.http.middlewares.chaospizza-error.errors.status=401,403,404,429,500,503
+        - traefik.http.middlewares.chaospizza-error.errors.query=/{status}.html
+  db:
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_USER: chaospizza
+      POSTGRES_PASSWORD: chaospizza
+      POSTGRES_DB: chaospizza
+    volumes:
+      - database2:/var/lib/postgresql/data
+    networks:
+      - internal
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 256M
+        reservations:
+          cpus: '0.125'
+          memory: 16M
+  db-backup:
+    image: nomaster/postgres-backup
+    volumes:
+      - backup:/backup
+    networks:
+      - internal
+    environment:
+      PGUSER: chaospizza
+      PGPASSWORD: chaospizza
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5
 
 volumes:
-  database:
   database2:
   backup:
 

--- a/enabled/chaospizza.yml
+++ b/enabled/chaospizza.yml
@@ -1,83 +1,13 @@
 version: '3.7'
 
 services:
-  app:
-    image: chaosdorf/chaospizza:latest
-    environment:
-      - DJANGO_ALLOWED_HOSTS=pizza.chaosdorf.space
-      - DJANGO_SETTINGS_MODULE=config.settings.prod
-      - DJANGO_DATABASE_URL=postgresql://chaospizza:chaospizza@db:5432/chaospizza
-    secrets:
-      - source: CHAOSPIZZA_DJANGO_SECRET_KEY
-        target: DJANGO_SECRET_KEY
-      - source: CHAOSPIZZA_SENTRY_DSN
-        target: SENTRY_DSN
-    networks:
-      - internal
-      - traefik
-    deploy:
-      mode: replicated
-      replicas: 1
-      restart_policy:
-        delay: 60s
-        max_attempts: 5
-      resources:
-        limits:
-          cpus: '0.50'
-          memory: 256M
-        reservations:
-          cpus: '0.125'
-          memory: 64M
-      labels:
-        - traefik.docker.network=traefik_net
-        - traefik.http.services.chaospizza.loadbalancer.server.port=8000
-        - "traefik.http.routers.chaospizza.rule=Host(`pizza.chaosdorf.space`)"
-        - traefik.http.routers.chaospizza.middlewares=global-headers@file,chaospizza-error@docker
-        - traefik.http.routers.chaospizza.service=chaospizza@docker
-        - traefik.http.routers.chaospizza.tls=true
-        - traefik.http.routers.chaospizza.tls.certresolver=default
-        - traefik.http.routers.chaospizza.tls.domains[0].main=*.chaosdorf.space
-        - traefik.http.middlewares.chaospizza-error.errors.service=error@docker
-        - traefik.http.middlewares.chaospizza-error.errors.status=401,403,404,429,500,503
-        - traefik.http.middlewares.chaospizza-error.errors.query=/{status}.html
   db:
-    image: postgres:9.6
-    environment:
-      POSTGRES_USER: chaospizza
-      POSTGRES_PASSWORD: chaospizza
-      POSTGRES_DB: chaospizza
-    volumes:
-      - database:/var/lib/postgresql/data
-    networks:
-      - internal
+    image: hello-world
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        delay: 60s
-        max_attempts: 5
-      resources:
-        limits:
-          cpus: '0.50'
-          memory: 256M
-        reservations:
-          cpus: '0.125'
-          memory: 16M
-  db-backup:
-    image: nomaster/postgres-backup
-    volumes:
-      - backup:/backup
-    networks:
-      - internal
-    environment:
-      PGUSER: chaospizza
-      PGPASSWORD: chaospizza
-    deploy:
-      mode: replicated
-      replicas: 1
-      restart_policy:
-        delay: 60s
-        max_attempts: 5
+        condition: none
 
 volumes:
   database:


### PR DESCRIPTION
This uses tianon/postgres-upgrade to upgrade Postgres as described in #14.
It's quite a bit complicated, but I think I managed to get it to work (at least it worked on my machine :upside_down_face: ).

Some things of note:
 * The full diff is not really interesting, each commit has a diff and they have to be individually deployed in this exact order (and wait for it to finish!).
 * Not including a service does not mean it gets stopped. This means that the app keeps running during the upgrade and will throw exceptions when it gets accessed. Also, this means that they could keep being there which would bring the size of the diffs down.
 * The old database doesn't get dropped. Reverting this PR works.