### PR TITLE
 chore(mete): Upgrade postgres from 10 to 14

### DIFF
--- a/enabled/mete.yml
+++ b/enabled/mete.yml
@@ -9,13 +9,10 @@ services:
       restart_policy:
         condition: none
   db:
-    image: tianon/postgres-upgrade:10-to-14
-    environment:
-      PGPASSWORD: mete
-      POSTGRES_INITDB_ARGS: --pwfile=<(echo mete)
+    image: busybox:1.34
+    command: ["sh", "-c", "echo 'host all all all md5' >> /database/pg_hba.conf"]
     volumes:
-      - database:/var/lib/postgresql/10/data
-      - database2:/var/lib/postgresql/14/data
+      - database2:/database
     deploy:
       mode: replicated
       replicas: 1

--- a/enabled/mete.yml
+++ b/enabled/mete.yml
@@ -2,64 +2,26 @@ version: '3.7'
 
 services:
   app:
-    image: chaosdorf/mete:latest
-    environment:
-      - RAILS_ENV=production
-      - SECRET_KEY_BASE=yoloyolo123
-    secrets:
-      - source: METE_SENTRY_DSN
-        target: SENTRY_DSN
-    volumes:
-      - system:/app/public/system
-    networks:
-      - internal
-      - traefik
+    image: hello-world
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        delay: 60s
-        max_attempts: 5
-      labels:
-        - traefik.docker.network=traefik_net
-        - traefik.http.services.mete.loadbalancer.server.port=80
-        - "traefik.http.routers.mete-http.rule=Host(`mete.chaosdorf.space`) || Host(`mete`)"
-        - traefik.http.routers.mete-http.middlewares=global-headers@file
-        - traefik.http.routers.mete-http.service=mete@docker
-        - "traefik.http.routers.mete-https.rule=Host(`mete.chaosdorf.space`) || Host(`mete`)"
-        - traefik.http.routers.mete-https.middlewares=global-headers@file
-        - traefik.http.routers.mete-https.service=mete@docker
-        - traefik.http.routers.mete-https.tls=true
-        - traefik.http.routers.mete-https.tls.certresolver=default
-        - traefik.http.routers.mete-https.tls.domains[0].main=*.chaosdorf.space
+        condition: none
   db:
-    image: postgres:10-alpine
-    environment:
-      POSTGRES_PASSWORD: mete
-    volumes:
-      - database:/var/lib/postgresql/data
-    networks:
-      - internal
+    image: hello-world
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        delay: 60s
-        max_attempts: 5
+        condition: none
   db-backup:
-    image: nomaster/postgres-backup
-    environment:
-      PGPASSWORD: mete
-    volumes:
-      - backup:/backup
-    networks:
-      - internal
+    image: hello-world
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        delay: 60s
-        max_attempts: 5
+        condition: none
 
 volumes:
   system:

--- a/enabled/mete.yml
+++ b/enabled/mete.yml
@@ -2,33 +2,67 @@ version: '3.7'
 
 services:
   app:
-    image: hello-world
-    deploy:
-      mode: replicated
-      replicas: 1
-      restart_policy:
-        condition: none
-  db:
-    image: busybox:1.34
-    command: ["sh", "-c", "echo 'host all all all md5' >> /database/pg_hba.conf"]
+    image: chaosdorf/mete:latest
+    environment:
+      - RAILS_ENV=production
+      - SECRET_KEY_BASE=yoloyolo123
+    secrets:
+      - source: METE_SENTRY_DSN
+        target: SENTRY_DSN
     volumes:
-      - database2:/database
+      - system:/app/public/system
+    networks:
+      - internal
+      - traefik
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        condition: none
+        delay: 60s
+        max_attempts: 5
+      labels:
+        - traefik.docker.network=traefik_net
+        - traefik.http.services.mete.loadbalancer.server.port=80
+        - "traefik.http.routers.mete-http.rule=Host(`mete.chaosdorf.space`) || Host(`mete`)"
+        - traefik.http.routers.mete-http.middlewares=global-headers@file
+        - traefik.http.routers.mete-http.service=mete@docker
+        - "traefik.http.routers.mete-https.rule=Host(`mete.chaosdorf.space`) || Host(`mete`)"
+        - traefik.http.routers.mete-https.middlewares=global-headers@file
+        - traefik.http.routers.mete-https.service=mete@docker
+        - traefik.http.routers.mete-https.tls=true
+        - traefik.http.routers.mete-https.tls.certresolver=default
+        - traefik.http.routers.mete-https.tls.domains[0].main=*.chaosdorf.space
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_PASSWORD: mete
+    volumes:
+      - database2:/var/lib/postgresql/data
+    networks:
+      - internal
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5
   db-backup:
-    image: hello-world
+    image: nomaster/postgres-backup
+    environment:
+      PGPASSWORD: mete
+    volumes:
+      - backup:/backup
+    networks:
+      - internal
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
-        condition: none
+        delay: 60s
+        max_attempts: 5
 
 volumes:
   system:
-  database:
   database2:
   backup:
 

--- a/enabled/mete.yml
+++ b/enabled/mete.yml
@@ -9,7 +9,13 @@ services:
       restart_policy:
         condition: none
   db:
-    image: hello-world
+    image: tianon/postgres-upgrade:10-to-14
+    environment:
+      PGPASSWORD: mete
+      POSTGRES_INITDB_ARGS: --pwfile=<(echo mete)
+    volumes:
+      - database:/var/lib/postgresql/10/data
+      - database2:/var/lib/postgresql/14/data
     deploy:
       mode: replicated
       replicas: 1
@@ -26,6 +32,7 @@ services:
 volumes:
   system:
   database:
+  database2:
   backup:
 
 networks:


### PR DESCRIPTION
This uses tianon/postgres-upgrade to upgrade Postgres as described in #14. (It is very similar to #22.)

Some things of note:
 * The full diff is not really interesting, each commit has a diff and they have to be individually deployed in this exact order (and wait for it to finish!).
 * The old database doesn't get dropped. Reverting this PR works.