### PR TITLE
feat(snmp): Expose snmp exporter to network

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ When running swarm on localhost, make sure to add DNS records e.g. to `/etc/host
 127.0.0.1 ympd.chaosdorf.space
 127.0.0.1 traefik.chaosdorf.space
 127.0.0.1 glitchtip.chaosdorf.space
+127.0.0.1 snmp.chaosdorf.space
 127.0.0.1 swarmpit
 127.0.0.1 portainer
 127.0.0.1 pizza
@@ -68,6 +69,7 @@ When running swarm on localhost, make sure to add DNS records e.g. to `/etc/host
 127.0.0.1 ympd
 127.0.0.1 traefik
 127.0.0.1 glitchtip
+127.0.0.1 snmp
 ```
 
 Portainer and swarmpit are fancy management web UIs and can be deployed tor testing.

--- a/enabled/snmp.yml
+++ b/enabled/snmp.yml
@@ -7,6 +7,10 @@ networks:
   internal:
   dashpi_internal:
     external: true
+  traefik:
+    driver: overlay
+    external: true
+    name: traefik_net
 
 configs:
   snmp:
@@ -24,12 +28,25 @@ services:
       - 9116
     networks:
       - internal
+      - traefik
     deploy:
       mode: replicated
       replicas: 1
       restart_policy:
         delay: 60s
         max_attempts: 5
+      labels:
+        - traefik.docker.network=traefik_net
+        - traefik.http.services.snmp.loadbalancer.server.port=9116
+        - "traefik.http.routers.snmp-http.rule=Host(`snmp.chaosdorf.space`) || Host(`snmp`)"
+        - traefik.http.routers.snmp-http.middlewares=global-headers@file
+        - traefik.http.routers.snmp-http.service=snmp@docker
+        - "traefik.http.routers.snmp-https.rule=Host(`snmp.chaosdorf.space`) || Host(`snmp`)"
+        - traefik.http.routers.snmp-https.middlewares=global-headers@file
+        - traefik.http.routers.snmp-https.service=snmp@docker
+        - traefik.http.routers.snmp-https.tls=true
+        - traefik.http.routers.snmp-https.tls.certresolver=default
+        - traefik.http.routers.snmp-https.tls.domains[0].main=*.chaosdorf.space
   prometheus:
     image: prom/prometheus
     configs:


### PR DESCRIPTION
@derf mentioned having the snmp data available for scraping would be nice. This could also be put on the chaosdorf.de dashboard.