### PR TITLE
feat: Add snowflake

### DIFF
--- a/enabled/snowflake.yml
+++ b/enabled/snowflake.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  app:
+    image: thetorproject/snowflake-proxy:latest
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        delay: 60s
+        max_attempts: 5


### PR DESCRIPTION
[Snowflake](https://snowflake.torproject.org/) is a Tor-thingy to allow people to bypass internet censorship via WebRTC. The easiest way to participate is a browser extension, but there's also a standalone server.

This just connects to a Tor bridge and does not expose our internal services.