### PR TITLE
feat: Make apps reachable via IPv6 (closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The Vagrantfile remaps this to 8080 and 4443.
 
 ## Notes
 
+### DNS
+
 Traefik does not manage DNS records yet.
 
 When running swarm on localhost, make sure to add DNS records e.g. to `/etc/hosts`:
@@ -73,4 +75,18 @@ When running swarm on localhost, make sure to add DNS records e.g. to `/etc/host
 127.0.0.1 snmp
 ```
 
+### Disabled containers
+
 Portainer and swarmpit are fancy management web UIs and can be deployed tor testing.
+
+### IPv6
+
+Docker has [experimental `ip6tables` support](https://github.com/moby/moby/pull/41622).
+When enabling it (and
+[reconfiguring `docker_gwbridge`](https://github.com/robbertkl/docker-ipv6nat/blob/master/README.md#swarm-mode-support)
+), containers get internal IPv6 addresses and might be able to reach external
+hosts via IPv6. This does not seem to work for the ingress network, though.
+
+That's why forwarded ports are marked with `mode: host` which bypasses Swarm's
+load balancing.
+

--- a/configs/traefik-static.toml
+++ b/configs/traefik-static.toml
@@ -1,3 +1,10 @@
+[entryPoints]
+  [entryPoints.web]
+    address = ":80"
+
+  [entryPoints.websecure]
+    address = ":443"
+
 [providers]
   [providers.file]
     filename = "/etc/traefik/dynamic.toml"

--- a/enabled/siamqtt.yml
+++ b/enabled/siamqtt.yml
@@ -9,7 +9,9 @@ services:
     secrets:
       - SIAMQTT_SENTRY_DSN
     ports:
-      - 1001:1001
+      - published: 1001
+        target: 1001
+        mode: host
     deploy:
       mode: replicated
       replicas: 1

--- a/enabled/traefik.yml
+++ b/enabled/traefik.yml
@@ -7,7 +7,7 @@ services:
       CF_API_EMAIL: account+cloudflare@chaosdorf.de
       CF_API_KEY_FILE: /run/secrets/CF_API_KEY
     configs:
-      - source: static
+      - source: static2
         target: /etc/traefik/traefik.toml
       - source: dynamic
         target: /etc/traefik/dynamic.toml
@@ -21,8 +21,12 @@ services:
     networks:
       - traefik
     ports:
-      - 80:80
-      - 443:80
+      - published: 80
+        target: 80
+        mode: host
+      - published: 443
+        target: 443
+        mode: host
     deploy:
       mode: global
       placement:
@@ -87,7 +91,7 @@ networks:
     name: traefik_net
 
 configs:
-  static:
+  static2:
     file: ../configs/traefik-static.toml
   dynamic:
     file: ../configs/traefik-dynamic.toml


### PR DESCRIPTION
Docker has [experimental `ip6tables` support](https://github.com/moby/moby/pull/41622).
When enabling it (and [reconfiguring `docker_gwbridge`](https://github.com/robbertkl/docker-ipv6nat/blob/master/README.md#swarm-mode-support)), containers get internal IPv6 addresses and might be able to reach external
hosts via IPv6. This does not seem to work for the ingress network, though.

That's why forwarded ports are marked with `mode: host` which bypasses Swarm's
load balancing.